### PR TITLE
feat: Improve performance preventing deepcopy

### DIFF
--- a/lib/ansible_variables/utils/vars.py
+++ b/lib/ansible_variables/utils/vars.py
@@ -82,7 +82,8 @@ class VariableSource:
 
         for ffile in self.files:
             display.vvv("Checking file %s for occurrence of variable %s" % (ffile, self.name))
-            if loader.load_from_file(ffile) and self.name in loader.load_from_file(ffile):
+            fvars = loader.load_from_file(ffile, unsafe=True)
+            if fvars and self.name in fvars:
                 occurrences.append(ffile)
 
         return occurrences

--- a/lib/ansible_variables/utils/vars.py
+++ b/lib/ansible_variables/utils/vars.py
@@ -82,8 +82,11 @@ class VariableSource:
 
         for ffile in self.files:
             display.vvv("Checking file %s for occurrence of variable %s" % (ffile, self.name))
-            fvars = loader.load_from_file(ffile, unsafe=True)
-            if fvars and self.name in fvars:
+
+            # Setting unsafe=True will prevent deepcopy and will help with performance
+            # and it's safe because we're not modifying the content
+            content = loader.load_from_file(ffile, unsafe=True)
+            if content and self.name in content:
                 occurrences.append(ffile)
 
         return occurrences


### PR DESCRIPTION
Hi,
using the tool I noticed that, at least for very big inventories, `file_occurences` function was taking a lot of time. Digging into the problem I found out that a very easy and quick solution is to call `load_from_file` with `unsafe=True` (we're not really touching the variables so it's safe to be unsafe).

Here you can see the time comparison:
```
# main version
$ time python lib/ansible_variables/cli/variables.py -v -i big_inventory webserver1 > /dev/null

real    1m36,652s
user    1m35,620s
sys     0m1,000s

# modified version
$ time python lib/ansible_variables/cli/variables.py -v -i big_inventory webserver1 > /dev/null

real    0m2,219s
user    0m2,145s
sys     0m0,051s
````

A quite significant improvement, I would say.