### PR TITLE
Add support for Ansible core < 13

### DIFF
--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -139,7 +139,7 @@ class VariablesCLI(CLI):
 
 def main(args=None):
     if hasattr(VariablesCLI, "cli_executor"):
-        exit_code = VariablesCLI.cli_executor(args)
+        VariablesCLI.cli_executor(args)
     else:
         if args is None:
             args = sys.argv
@@ -151,12 +151,10 @@ def main(args=None):
                 "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
             )
             display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
-            exit_code = 6
+            return 6
         else:
             cli = VariablesCLI(args)
-            exit_code = cli.run()
-
-    return exit_code
+            return cli.run()
 
 
 if __name__ == "__main__":

--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -145,10 +145,12 @@ def main(args=None):
             args = sys.argv
 
         try:
-            args = [to_text(a, errors='surrogate_or_strict') for a in args]
+            args = [to_text(a, errors="surrogate_or_strict") for a in args]
         except UnicodeError:
-            display.error('Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8')
-            display.display(u"The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
+            display.error(
+                "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
+            )
+            display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
             exit_code = 6
         else:
             cli = VariablesCLI(args)

--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -151,10 +151,10 @@ def main(args=None):
                 "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
             )
             display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
-            return 6
-        else:
-            cli = VariablesCLI(args)
-            return cli.run()
+            sys.exit(6)
+
+        cli = VariablesCLI(args)
+        sys.exit(cli.run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,
while the README.md says:
> Tested with ansible-core 2.11 - 2.15.

Actually trying to run it with `ansible-core` version prior to 2.13 fails. This because the classmethod `cli_executor` has been introduced in `ansible.cli` starting from `anisble-core` 2.13.

This PR add retro-compatibility without changing current behaviour.