### PR TITLE
feat: support ansible-core 2.11 and 2.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: Tox
 
 on:
   push:
-    branches: ["main"]
+    branches: ["*"]
   pull_request:
     branches: ["main"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,7 @@ repos:
           - ansible-core>=2.11.0
           - rich
           - pytest
+        stages: [manual] # not working if only single files are passed
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/lib/ansible_variables/cli/__init__.py
+++ b/lib/ansible_variables/cli/__init__.py
@@ -1,0 +1,104 @@
+import errno
+import sys
+import traceback
+from pathlib import Path
+
+from ansible import constants as C
+from ansible import context
+from ansible.cli import CLI as ACLI
+from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
+from ansible.module_utils._text import to_text
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class CLI(ACLI):
+    """
+    Patched `ansible.cli.CLI` class with `CLI.cli_executor` classmethod backported for ansible-core 2.11
+    and ansible-core 2.12.
+    Can be removed as soon as we will drop the support for ansible-core < 2.13.
+
+    (see https://github.com/ansible/ansible/pull/76021)
+    """
+
+    @classmethod
+    def cli_executor(cls, args=None):
+        # no change for ansible-core >= 2.13
+        if hasattr(super(), "cli_executor"):
+            return super().cli_executor(args=args)
+
+        # backporting code from https://github.com/ansible/ansible/blob/v2.13.9/lib/ansible/cli/__init__.py#L574
+        else:
+            if args is None:
+                args = sys.argv
+
+            try:
+                display.debug("starting run")
+
+                ansible_dir = Path("~/.ansible").expanduser()
+                try:
+                    ansible_dir.mkdir(mode=0o700)
+                except OSError as exc:
+                    if exc.errno != errno.EEXIST:
+                        display.warning(
+                            "Failed to create the directory '%s': %s"
+                            % (ansible_dir, to_text(exc, errors="surrogate_or_replace"))
+                        )
+                else:
+                    display.debug("Created the '%s' directory" % ansible_dir)
+
+                try:
+                    args = [to_text(a, errors="surrogate_or_strict") for a in args]
+                except UnicodeError:
+                    display.error(
+                        """Command line args are not in utf-8, unable to continue.
+                        Ansible currently only understands utf-8"""
+                    )
+                    display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
+                    exit_code = 6
+                else:
+                    cli = cls(args)
+                    exit_code = cli.run()
+
+            except AnsibleOptionsError as exc:
+                cli.parser.print_help()
+                display.error(to_text(exc), wrap_text=False)
+                exit_code = 5
+            except AnsibleParserError as exc:
+                display.error(to_text(exc), wrap_text=False)
+                exit_code = 4
+            # TQM takes care of these, but leaving comment to reserve the exit codes
+            #    except AnsibleHostUnreachable as e:
+            #        display.error(str(e))
+            #        exit_code = 3
+            #    except AnsibleHostFailed as e:
+            #        display.error(str(e))
+            #        exit_code = 2
+            except AnsibleError as e:
+                display.error(to_text(e), wrap_text=False)
+                exit_code = 1
+            except KeyboardInterrupt:
+                display.error("User interrupted execution")
+                exit_code = 99
+            except Exception as e:
+                if C.DEFAULT_DEBUG:
+                    # Show raw stacktraces in debug mode, It also allow pdb to
+                    # enter post mortem mode.
+                    raise
+                have_cli_options = bool(context.CLIARGS)
+                display.error("Unexpected Exception, this is probably a bug: %s" % to_text(e), wrap_text=False)
+                if not have_cli_options or have_cli_options and context.CLIARGS["verbosity"] > 2:
+                    log_only = False
+                    if hasattr(e, "orig_exc"):
+                        display.vvv("\nexception type: %s" % to_text(type(e.orig_exc)))
+                        why = to_text(e.orig_exc)
+                        if to_text(e) != why:
+                            display.vvv("\noriginal msg: %s" % why)
+                else:
+                    display.display("to see the full traceback, use -vvv")
+                    log_only = True
+                display.display("the full traceback was:\n\n%s" % to_text(traceback.format_exc()), log_only=log_only)
+                exit_code = 250
+
+            sys.exit(exit_code)

--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -139,7 +139,7 @@ class VariablesCLI(CLI):
 
 def main(args=None):
     if hasattr(VariablesCLI, "cli_executor"):
-        exit_code = VariablesCLI.cli_executor(args)
+        VariablesCLI.cli_executor(args)
     else:
         if args is None:
             args = sys.argv
@@ -147,14 +147,14 @@ def main(args=None):
         try:
             args = [to_text(a, errors='surrogate_or_strict') for a in args]
         except UnicodeError:
-            display.error('Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8')
-            display.display(u"The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
-            exit_code = 6
+            display.error(
+                "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
+            )
+            display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
+            return 6
         else:
             cli = VariablesCLI(args)
-            exit_code = cli.run()
-
-    return exit_code
+            return cli.run()
 
 
 if __name__ == "__main__":

--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -1,16 +1,14 @@
 import argparse
-import sys
-import traceback
 
 import rich
 from ansible import context
-from ansible.cli import CLI
 from ansible.cli.arguments import option_helpers as opt_help
 from ansible.errors import AnsibleOptionsError
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils._text import to_native
 from ansible.utils.display import Display
 
 from ansible_variables import __version__
+from ansible_variables.cli import CLI
 from ansible_variables.utils.vars import variable_sources
 
 display = Display()
@@ -138,23 +136,7 @@ class VariablesCLI(CLI):
 
 
 def main(args=None):
-    if hasattr(VariablesCLI, "cli_executor"):
-        VariablesCLI.cli_executor(args)
-    else:
-        if args is None:
-            args = sys.argv
-
-        try:
-            args = [to_text(a, errors='surrogate_or_strict') for a in args]
-        except UnicodeError:
-            display.error(
-                "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
-            )
-            display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
-            sys.exit(6)
-
-        cli = VariablesCLI(args)
-        sys.exit(cli.run())
+    VariablesCLI.cli_executor(args)
 
 
 if __name__ == "__main__":

--- a/lib/ansible_variables/cli/variables.py
+++ b/lib/ansible_variables/cli/variables.py
@@ -151,10 +151,10 @@ def main(args=None):
                 "Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8"
             )
             display.display("The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
-            return 6
-        else:
-            cli = VariablesCLI(args)
-            return cli.run()
+            sys.exit(6)
+
+        cli = VariablesCLI(args)
+        sys.exit(cli.run())
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,15 @@
 import pytest
 from ansible import constants as C
 
-from ansible_variables.cli.variables import VariablesCLI
+from ansible_variables.cli.variables import VariablesCLI, main
 
 C.set_constant("CONFIG_FILE", "tests/test_data/ansible.cfg")
 C.set_constant("DEFAULT_HOST_LIST", "tests/test_data/inventory")
 
 
-def test_parse(capsys):
-    """Test ansible-variables parse"""
-
-    variables_cli = VariablesCLI(["ansible-variables"])
+def test_main(capsys):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        variables_cli.parse()
+        main(["ansible-variables"])
     assert pytest_wrapped_e.type == SystemExit
     assert "ansible-variables: error: the following arguments are required: host" in capsys.readouterr().err
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     linters
-    py39-ansible{211,212,213,214,devel}
+    py39-ansible{211,212,213,214,215,devel}
     py310
     py311
 minversion = 4.4.11
@@ -23,6 +23,7 @@ deps =
     ansible212: ansible-core==2.12.*
     ansible213: ansible-core==2.13.*
     ansible214: ansible-core==2.14.*
+    ansible215: ansible-core==2.15.*
     ansibledevel: git+https://github.com/ansible/ansible
 
 commands =


### PR DESCRIPTION
Backporting the `cli_executor` classmethod from `ansible.cli.CLI` which was introduced in ansible-core 2.13 (https://github.com/ansible/ansible/pull/76021) to support ansible-core 2.11 and ansible-core 2.12.

fixes #23 

Thanks to @andreatomassetti  who came up with the idea in #21 