### PR TITLE
fix: migrate to release please v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,28 +15,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # release please
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: python
-          package-name: ansible-variables
 
       # build & publish to PyPI
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
         if: ${{ steps.release.outputs.release_created }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build
         if: ${{ steps.release.outputs.release_created }}
+
       - name: Build package
         run: python -m build
         if: ${{ steps.release.outputs.release_created }}
+
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241
         with:


### PR DESCRIPTION
* migrate from release-please v3 to release-please v4 (see #54)
* change GitHub action from google-github-actions/ to googleapis/ (see https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#migration)
* using Python 3.11 for packaging