### PR TITLE
Allow using Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,10 @@ dependencies = [
     "ansible-core >=2.12.0,<8; python_version == '3.10'",
     "ansible-core >=2.14.0,<8; python_version == '3.11'",
     "ansible-core >=2.16.0,<8; python_version == '3.12'",
+    "ansible-core >=2.18.0,<8; python_version == '3.13'",
     "rich",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 authors = [
     {"name" = "Christoph Hille", "email" = "hille721@gmail.com"}
 ]


### PR DESCRIPTION
fixes #114 

- Allow using Python 3.13
- Require ansible-core 2.18 or higher for Python 3.13, as only this version supports Python 3.13